### PR TITLE
Update TimeBarChart.vue スライダーを動かして1年以上表示した時に、ラベルの月が1年分しか表示されない問題の改善

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -222,7 +222,7 @@ export default {
                 }
               }
             },
-            /*{
+            /* {
               id: 'month',
               stacked: true,
               gridLines: {
@@ -262,7 +262,7 @@ export default {
               time: {
                 unit: 'month'
               }
-            }*/
+            } */
           ],
           yAxes: [
             {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -218,7 +218,7 @@ export default {
                 maxRotation: 90,
                 minRotation: 0,
                 callback: label => {
-                  return label.split('/')[0]+'月'+label.split('/')[1]+'日'
+                  return label.split('/')[0] + '月' + label.split('/')[1] + '日'
                 }
               }
             },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -215,14 +215,14 @@ export default {
                 fontSize: 9,
                 maxTicksLimit: 20,
                 fontColor: '#808080',
-                maxRotation: 0,
+                maxRotation: 90,
                 minRotation: 0,
                 callback: label => {
-                  return label.split('/')[1]
+                  return label.split('/')[0]+'月'+label.split('/')[1]+'日'
                 }
               }
             },
-            {
+            /*{
               id: 'month',
               stacked: true,
               gridLines: {
@@ -262,7 +262,7 @@ export default {
               time: {
                 unit: 'month'
               }
-            }
+            }*/
           ],
           yAxes: [
             {


### PR DESCRIPTION
スライダーを動かして1年以上表示した時に、ラベルの月が1年分しか表示されない問題の改善

## 📝 関連issue / Related Issues #57
データが1年を超えた場合のグラフ表示について #57

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #57

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
変更方針
月のところがバグっているので
日付けの表示のところに月の表示を加え、月の表示をしないようにする。
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="432" alt="fix1" src="https://user-images.githubusercontent.com/83255674/117595662-67c5a800-b17c-11eb-9c60-5c3e39f7a2e7.png">